### PR TITLE
Use custom web options for healthcheck

### DIFF
--- a/lib/mrsk/commands/healthcheck.rb
+++ b/lib/mrsk/commands/healthcheck.rb
@@ -11,6 +11,7 @@ class Mrsk::Commands::Healthcheck < Mrsk::Commands::Base
       "--label", "service=#{container_name}",
       *web.env_args,
       *config.volume_args,
+      *web.option_args,
       config.absolute_image,
       web.cmd
   end

--- a/test/commands/healthcheck_test.rb
+++ b/test/commands/healthcheck_test.rb
@@ -30,6 +30,13 @@ class CommandsHealthcheckTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run with custom options" do
+    @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "options" => { "mount" => "somewhere" } } }
+    assert_equal \
+      "docker run --detach --name healthcheck-app-123 --publish 3999:3000 --label service=healthcheck-app --mount \"somewhere\" dhh/app:123",
+      new_command.run.join(" ")
+  end
+
   test "curl" do
     assert_equal \
       "curl --silent --output /dev/null --write-out '%{http_code}' --max-time 2 http://localhost:3999/up",


### PR DESCRIPTION
If the web role has custom options, ensure these are used for the
healthcheck.
